### PR TITLE
Add a Error::Panic variant, and run the solution function under catch_unwind.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -12,4 +14,6 @@ pub enum Error {
 	Incorrect,
 	#[error("rate limited - wait {0}")]
 	RateLimit(String),
+	#[error("the solution function panicked")]
+	Panic(Box<dyn Any + Send + 'static>),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,8 @@ where
 		Some(path) => get_input_or_file(session, year, day, path),
 		None => get_input(session, year, day),
 	}?;
-	let answer = solution(&input);
+	let answer = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| solution(&input)))
+		.map_err(Error::Panic)?;
 	post_answer(session, year, day, part, answer)?;
 	Ok(())
 }


### PR DESCRIPTION
Adds an `Error::Panic` variant, and runs the solution function under `catch_unwind`, so that panics in the solution will be caught and treated as an error instead of crashing.

---

My use case:

In my template, I'd prefer to attempt running part 2 first, and only run part 1 if part 2 fails. But when I initially have only part 1 implemented, part 2 just panics.

<details> <summary>My template</summary>

```rs
use aoc_driver::*;

fn part_1(#[allow(unused)] input: &str) -> String {
    unimplemented!()
}
fn part_2(#[allow(unused)] input: &str) -> String {
    unimplemented!()
}

fn main() {
    let session = std::fs::read_to_string(".session.txt").unwrap();
    if let Err(error) = aoc_magic!(session.trim(), 2022:$day:2, part_2) {
        eprintln!("Part 2 failed: {error:?}");
        if let Err(error) = aoc_magic!(session.trim(), 2022:$day:1, part_1) {
            eprintln!("Part 1 failed: {error:?}");
        }
    }
}

```
</details>