### PR TITLE
Local cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,11 @@ repository = "https://github.com/Ben-Lichtman/aoc_driver"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-chrono = { version = "0.4.23", features = ["serde"] }
-serde = { version = "1.0.148", features = ["derive", "std", "rc"] }
-serde_json = "1.0.89"
+chrono = { version = "0.4.23", features = ["serde"], optional = true }
+serde = { version = "1.0.148", features = ["derive", "std", "rc"], optional = true }
+serde_json = { version = "1.0.89", optional = true }
 thiserror = "1.0.37"
 ureq = "2.5.0"
+
+[features]
+local_cache = ["serde", "serde_json", "chrono"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,8 @@ repository = "https://github.com/Ben-Lichtman/aoc_driver"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+chrono = { version = "0.4.23", features = ["serde"] }
+serde = { version = "1.0.148", features = ["derive", "std", "rc"] }
+serde_json = "1.0.89"
 thiserror = "1.0.37"
 ureq = "2.5.0"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,122 @@
+use std::{collections::HashMap, path::Path, rc::Rc};
+
+use crate::{error::Error, Result};
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct Response {
+	submission_time: DateTime<Utc>,
+	response: Result<()>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct Cache {
+	/// Only stores the most important, most recent response actually received from the server.
+	/// Priority: Ok(()), Err(Incorrect), Err(RateLimit), Err(Panic/Ureq/IO)
+	part_1: HashMap<String, Rc<Response>>,
+	/// Only stores the most important, most recent response actually received from the server.
+	/// Priority: Ok(()), Err(Incorrect), Err(RateLimit), Err(Panic/Ureq/IO)
+	part_2: HashMap<String, Rc<Response>>,
+}
+
+/// Checks the local cache for the result.
+/// If the local cache contains that result as Ok(()) or Err(Error::Incorrect), return that.
+/// If the local cache contains an Err(Error::RateLimit) that was less than 30 seconds ago, return an appropriate rate limit response.
+/// Else, call the post_fn and add it's result to the cache and return it.
+pub fn cache_wrapper(
+	result: &str,
+	part: i32,
+	cache_path: Option<impl AsRef<Path>>,
+	post_fn: impl FnOnce(&str) -> Result<()>,
+) -> Result<()> {
+	if let Some(cache_path) = cache_path {
+		let cache_path = cache_path.as_ref();
+
+		let mut full_cache = std::fs::read_to_string(cache_path)
+			.ok()
+			.and_then(|cache_data| serde_json::from_str::<Cache>(&cache_data).ok())
+			.unwrap_or_default();
+		let cache = if part == 1 {
+			&mut full_cache.part_1
+		} else {
+			&mut full_cache.part_2
+		};
+
+		let final_response: Rc<Response>;
+
+		match cache.entry(result.to_owned()) {
+			std::collections::hash_map::Entry::Occupied(mut entry) => {
+				let Response {
+					submission_time,
+					response,
+				} = &**entry.get();
+				match response {
+					Ok(()) => return Ok(()),
+					Err(Error::Incorrect) => return Err(Error::Incorrect),
+					Err(Error::RateLimit(time)) => {
+						let remaining_seconds: Option<u64>;
+						if let Some(ratelimit_seconds) = time
+							.strip_suffix("s")
+							.and_then(|s| s.parse::<i64>().ok())
+							.map(Duration::seconds)
+						{
+							let time_since_ratelimit_response = Utc::now() - *submission_time;
+							remaining_seconds = ratelimit_seconds
+								.checked_sub(&time_since_ratelimit_response)
+								.and_then(|d| d.num_seconds().try_into().ok());
+						} else {
+							remaining_seconds = None;
+						}
+						if let Some(remaining_seconds) = remaining_seconds {
+							return Err(Error::RateLimit(format!("{remaining_seconds}s")));
+						} else {
+							let response = post_fn(result);
+							let response = Rc::new(Response {
+								submission_time: Utc::now(),
+								response,
+							});
+							entry.insert(response.clone());
+							final_response = response;
+						}
+					}
+					Err(_err) => {
+						let response = post_fn(result);
+						let response = Rc::new(Response {
+							submission_time: Utc::now(),
+							response,
+						});
+						entry.insert(response.clone());
+						final_response = response;
+					}
+				}
+			}
+			std::collections::hash_map::Entry::Vacant(entry) => {
+				let response = post_fn(result);
+				let response = Rc::new(Response {
+					submission_time: Utc::now(),
+					response,
+				});
+				entry.insert(response.clone());
+				final_response = response;
+			}
+		}
+
+		// If we didn't return early, the cache was modified, so overwrite the file.
+		if let Ok(cache_file) = std::fs::File::options()
+			.truncate(true)
+			.create(true)
+			.write(true)
+			.open(cache_path)
+		{
+			// Ignore cache writing errors
+			let _ = serde_json::to_writer(cache_file, &full_cache);
+		}
+		drop(full_cache);
+
+		Rc::try_unwrap(final_response).unwrap().response
+	} else {
+		post_fn(result)
+	}
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,22 @@
 use std::any::Any;
 
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Error, Serialize, Deserialize)]
+#[derive(Debug, Error)]
+#[cfg_attr(feature = "local_cache", derive(serde::Serialize, serde::Deserialize))]
 pub enum Error {
 	#[error("io error")]
-	IO(#[serde(skip)] Option<std::io::Error>),
+	IO(#[cfg_attr(feature = "local_cache", serde(skip))] Option<std::io::Error>),
 	#[error("ureq error")]
-	UReq(#[serde(skip)] Option<Box<ureq::Error>>),
+	UReq(#[cfg_attr(feature = "local_cache", serde(skip))] Option<Box<ureq::Error>>),
 	#[error("answer was incorrect")]
 	Incorrect,
 	#[error("rate limited - wait {0}")]
 	RateLimit(String),
 	#[error("the solution function panicked")]
-	Panic(#[serde(skip)] Option<Box<dyn Any + Send + 'static>>),
+	Panic(#[cfg_attr(feature = "local_cache", serde(skip))] Option<Box<dyn Any + Send + 'static>>),
 }
 
 impl From<std::io::Error> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,19 +1,26 @@
 use std::any::Any;
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Serialize, Deserialize)]
 pub enum Error {
 	#[error("io error")]
-	IO(#[from] std::io::Error),
+	IO(#[serde(skip)] Option<std::io::Error>),
 	#[error("ureq error")]
-	UReq(Box<ureq::Error>),
+	UReq(#[serde(skip)] Option<Box<ureq::Error>>),
 	#[error("answer was incorrect")]
 	Incorrect,
 	#[error("rate limited - wait {0}")]
 	RateLimit(String),
 	#[error("the solution function panicked")]
-	Panic(Box<dyn Any + Send + 'static>),
+	Panic(#[serde(skip)] Option<Box<dyn Any + Send + 'static>>),
+}
+
+impl From<std::io::Error> for Error {
+	fn from(error: std::io::Error) -> Self {
+		Error::IO(Some(error))
+	}
 }


### PR DESCRIPTION
Adds an optional `local_cache` cargo feature that creates a json file for each day at `./cache/{year}/{day}.json` that caches previous submissions' results. If an answer already received a "correct" or "incorrect" response from the server, return that without accessing the server. Otherwise, if a ratelimit error was recieved, calculate the time since that response and either try to submit again (if past the try-again time), or return a ratelimit error with the calculated remaining time (if the try-again time has not yet passed). Otherwise (the previous response was some other kind of error, or there was no previous response), try to submit and store that response.

My code's a bit messy (it's *very* indented and not well commented), but it works and I'm using it, so I figured I'd make the PR anyway. I may clean it up later.

Note: Technically, this is a semver-breaking change, since it modifies variant fields of a `pub enum`.
(Note: I also just realized that my last PR was also a semver-breaking change, since it added a variant to a non-`#[non_exhaustive]` enum. Oops! Sorry.)