### PR TITLE
Relax requirements on solution function.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ where
 /// Usage: `aoc_magic!(<session cookie>, <year>:<day>:<part>, <solution function>)`
 #[macro_export]
 macro_rules! aoc_magic {
-	($session:expr, $year:literal : $day:literal : $part:literal, $sol:path) => {{
+	($session:expr, $year:literal : $day:literal : $part:literal, $sol:expr) => {{
 		let mut input_path = std::path::PathBuf::from_iter(["inputs", &$year.to_string()]);
 		std::fs::create_dir_all(&input_path).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ pub fn calculate_and_post<SolOutput, SolFn>(
 ) -> Result<()>
 where
 	SolOutput: Display,
-	SolFn: Fn(&str) -> SolOutput,
+	SolFn: FnOnce(&str) -> SolOutput,
 {
 	let year = year.into();
 	let day = day.into();


### PR DESCRIPTION
Relaxes the `Fn(&str) -> SolOutput` bound to `FnOnce(&str) -> SolOutput`. The solution function is only run once, so it doesn't need to be `Fn` or `FnMut`.

Allows passing non-path expressions (e.g. closures) directly as the solution function to the `aoc_magic!` macro, e.g.
```rs
// previously
let closure = |input: &str| do_thing(input).unwrap();
aoc_magic(session, 2022:25:2, closure);
// now
aoc_magic(session, 2022:25:2, |input: &str| do_thing(input).unwrap());
```