### PR TITLE
Fix conditional compilation of local_cache feature

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@ impl From<std::io::Error> for Error {
 }
 
 #[derive(Debug, Clone)]
+#[cfg(feature = "local_cache")]
 #[cfg_attr(feature = "local_cache", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) enum ErrorSerializable {
 	IO,
@@ -32,6 +33,7 @@ pub(crate) enum ErrorSerializable {
 	Panic,
 }
 
+#[cfg(feature = "local_cache")]
 impl ErrorSerializable {
 	pub fn from(value: &Error) -> Self {
 		match value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,10 @@ pub mod error;
 
 pub use Part::*;
 
-use crate::{
-	cache::cache_wrapper,
-	error::{Error, Result},
-};
+#[cfg(feature = "local_cache")]
+use crate::cache::cache_wrapper;
+
+use crate::error::{Error, Result};
 use std::{
 	fmt::Display,
 	fs::File,
@@ -181,7 +181,7 @@ where
 	return cache_wrapper(cache_path, part, &answer, post_fn);
 
 	#[cfg(not(feature = "local_cache"))]
-	return post_fn(answer);
+	return post_fn(&answer);
 }
 
 /// Fetches the challenge input, calculate the answer, and post it to the AoC website


### PR DESCRIPTION
Building the crate without the local_cache feature currently leads to the following error
```
error[E0432]: unresolved import `crate::cache`
  --> /home/qther/.cargo/registry/src/index.crates.io-6f17d22bba15001f/aoc_driver-0.3.5/src/lib.rs:45:2
   |
45 |     cache::cache_wrapper,
   |     ^^^^^ could not find `cache` in the crate root

For more information about this error, try `rustc --explain E0432`.
```

This pull requests aims to fix that.