### PR TITLE
Cache the correct answer

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -39,14 +39,7 @@ fn get_remaining_time(submission_time: &DateTime<Utc>, rate_limit_str: &str) -> 
 		remaining_seconds = ratelimit_seconds
 			.checked_sub(&time_since_ratelimit_response)
 			.map(|d| d.num_seconds())
-			.and_then(|x| {
-				if x.is_positive() {
-					Some(x)
-				}
-				else {
-					None
-				}
-			});
+			.filter(|x| x.is_positive());
 	}
 	remaining_seconds
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -11,7 +11,15 @@ use std::{
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct Cache {
-	parts: HashMap<i32, HashMap<String, Response>>,
+	parts: HashMap<i32, PartCache>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct PartCache {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	correct_answer: Option<String>,
+	#[serde(flatten)]
+	answers: HashMap<String, Response>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -44,9 +52,12 @@ fn get_remaining_time(submission_time: &DateTime<Utc>, rate_limit_str: &str) -> 
 }
 
 /// Checks the local cache for the result.
-/// If the local cache contains that result as Ok(()) or Err(Error::Incorrect), return that.
-/// If the local cache contains an Err(Error::RateLimit) that was less than 30 seconds ago, return an appropriate rate limit response.
-/// Else, call the post_fn and add it's result to the cache and return it.
+/// If the local cache has the correct answer already, return Ok(()) if the result is equal to it, or Err(Error::Incorrect) if it is not.
+/// If the local cache contains the result as Ok(()), set the local cache's correct answer to the result and return Ok(()).
+/// If the local cache contains the result as Err(Error::Incorrect), return that.
+/// If the local cache contains the result as Err(Error::RateLimit) that was less than 30 seconds ago, return an appropriate rate limit response.
+/// 	TODO/FIXME: keep track of RateLimit for the whole part, not just individual answers.
+/// Else, call the post_fn and add its result to the cache and return it.
 pub fn cache_wrapper(
 	cache_path: Option<impl AsRef<Path>>,
 	part: i32,
@@ -63,14 +74,52 @@ pub fn cache_wrapper(
 
 		let part = full_cache.parts.entry(part).or_default();
 
-		let final_response = match part.entry(result.to_string()) {
+		if let Some(known_answer) = &part.correct_answer {
+			if result == known_answer {
+				return Ok(());
+			}
+			else {
+				return Err(Error::Incorrect);
+			}
+		}
+
+		// Deduplicate the same code from three branches below that handles posting the answer to the server and
+		// and handling the result, since its the same for all three cases.
+		// This is not a closure, because `$entry` can either be an `OccupiedEntry` or a `VacantEntry`.
+		macro_rules! post_result_and_handle_response {
+			($entry:ident) => {{
+				let response = post_fn(result);
+
+				let translated = match &response {
+					Ok(()) => {
+						part.correct_answer = Some(result.to_owned());
+						Ok(())
+					}
+					Err(e) => Err(ErrorSerializable::from(e)),
+				};
+
+				$entry.insert(Response {
+					submission_time: Utc::now(),
+					response: translated,
+				});
+				response
+			}};
+		}
+
+		let final_response = match part.answers.entry(result.to_string()) {
 			Entry::Occupied(mut entry) => {
 				let Response {
 					submission_time,
 					response,
 				} = entry.get();
 				match response {
-					Ok(()) => return Ok(()),
+					Ok(()) => {
+						// We can only reach here if `part.correct_answer` is `None`
+						// but the JSON had a correct answer, so set `part.correct_answer`
+						// to the correct answer to write to the JSON for future calls.
+						part.correct_answer = Some(result.to_owned());
+						Ok(())
+					}
 					Err(ErrorSerializable::Incorrect) => return Err(Error::Incorrect),
 					Err(ErrorSerializable::RateLimit(time)) => {
 						let remaining_seconds = get_remaining_time(submission_time, time);
@@ -79,54 +128,13 @@ pub fn cache_wrapper(
 							Some(remaining_seconds) => {
 								return Err(Error::RateLimit(format!("{remaining_seconds}s")))
 							}
-							None => {
-								let response = post_fn(result);
-
-								let translated = match &response {
-									Ok(()) => Ok(()),
-									Err(e) => Err(ErrorSerializable::from(e)),
-								};
-
-								entry.insert(Response {
-									submission_time: Utc::now(),
-									response: translated,
-								});
-								response
-							}
+							None => post_result_and_handle_response!(entry),
 						}
 					}
-					Err(_err) => {
-						let response = post_fn(result);
-
-						let translated = match &response {
-							Ok(()) => Ok(()),
-							Err(e) => Err(ErrorSerializable::from(e)),
-						};
-
-						entry.insert(Response {
-							submission_time: Utc::now(),
-							response: translated,
-						});
-
-						response
-					}
+					Err(_err) => post_result_and_handle_response!(entry),
 				}
 			}
-			Entry::Vacant(entry) => {
-				let response = post_fn(result);
-
-				let translated = match &response {
-					Ok(()) => Ok(()),
-					Err(e) => Err(ErrorSerializable::from(e)),
-				};
-
-				entry.insert(Response {
-					submission_time: Utc::now(),
-					response: translated,
-				});
-
-				response
-			}
+			Entry::Vacant(entry) => post_result_and_handle_response!(entry),
 		};
 
 		// If we didn't return early, the cache was modified, so overwrite the file.


### PR DESCRIPTION
Caches the known correct answer explicitly. On later submissions if the known correct answer is present in the cache, never access the server, just compare to the result to the known correct answer.

See also #7, but this does not _totally_ fix it. If the same cache file is used from the first time a submission is given for a problem, then it will fix the issue (since the cache file will record the correct answer, and know that any later different answer is wrong without asking the server). But if someone submits the correct answer and then submits using a new cache file, any response from the server will still be interpreted as that new answer being correct.

This is backwards-compatible with existing cache files[^1] (i.e. old cache files still parse), since it uses `#[serde(flatten)]` on the `answers` field of `PartCache`, so JSON object fields other than `"correct_answer"` will go into that `HashMap` as before.

Added a TODO/FIXME about non-answer-specific rate limit tracking, since the previous comment was inaccurate IIUC. That's probably not as big a deal as #7, since I assume people usually submit the same answer after seeing a ratelimit error.

<details> <summary> JSON example </summary>

(prettified)

```json
{
    "parts": {
        "1": {
            "correct_answer": "1234",
            "1234": {
                "submission_time": "2024-12-01T05:04:49.343695010Z",
                "response": {
                    "Ok": null
                }
            }
        },
        "2": {
            "correct_answer": "12345",
            "23456": {
                "submission_time": "2024-12-01T05:07:35.415425030Z",
                "response": {
                    "Err": "Incorrect"
                }
            },
            "12345": {
                "submission_time": "2024-12-01T05:08:45.355302998Z",
                "response": {
                    "Ok": null
                }
            }
        }
    }
}
```

</details>

[^1]: as long as no one tried to submit the literal string `correct_answer` as an answer